### PR TITLE
fix layout and battery lfe

### DIFF
--- a/badge.go
+++ b/badge.go
@@ -30,6 +30,7 @@ func profile() {
 		if btnA.Get() || btnB.Get() || btnC.Get() || btnUp.Get() || btnDown.Get() {
 			break
 		}
+		time.Sleep(200 * time.Millisecond)
 	}
 }
 
@@ -51,7 +52,7 @@ func demo() {
 
 func badgeProfile() {
 	display.ClearBuffer()
-	midW := int16(176)
+	midW := int16(167)
 	if profileErr == nil {
 		img := pixel.NewImageFromBytes[pixel.Monochrome](128, 128, []byte(profileImg))
 		if err := display.DrawBitmap(168, 0, img); err != nil {


### PR DESCRIPTION
Adjusted layout on badge so 128x128 profile image is given enough space. Suspect typo in setting midW variable in badgeProfile() was 176 should be 167. Also added sleep timer to button checking loop in function profile() to hopefully increase battery life.