### PR TITLE
Clear display before writing badge to avoid home screen afterglow

### DIFF
--- a/badge.go
+++ b/badge.go
@@ -50,7 +50,12 @@ func demo() {
 }
 
 func badgeProfile() {
+	display.ClearDisplay()
+	showRect(0, 0, WIDTH, 15, black)
+	showRect(0, 15, WIDTH, 15, white)
+	display.Display()
 	display.ClearBuffer()
+
 	midW := int16(176)
 	if profileErr == nil {
 		img := pixel.NewImageFromBytes[pixel.Monochrome](120, 128, []byte(profileImg))


### PR DESCRIPTION
The showRect logic is here to keep the current greyscale feel that I like.

Before:

![114D7868-BD1A-423A-96BB-1F651C796281_1_102_a](https://github.com/user-attachments/assets/d49304ab-bccd-4d91-93a1-c996ed058023)

After:

![058E3EED-5757-4F7A-9FDE-7CAFE0A91373_1_102_a](https://github.com/user-attachments/assets/6e2a9449-68cb-4e24-90e4-68f8369e8485)
